### PR TITLE
Add more generic random string function

### DIFF
--- a/friend/strings.py
+++ b/friend/strings.py
@@ -27,6 +27,20 @@ import re
 import string
 
 
+def random_string(length, charset):
+    """
+    Return a random string of the given length from the
+    given character set.
+
+    :param int length: The length of string to return
+    :param str charset: A string of characters to choose from
+    :returns: A random string
+    :rtype: str
+    """
+    n = len(charset)
+    return ''.join(charset[random.randrange(n)] for _ in range(length))
+
+
 def random_alphanum(length):
     """
     Return a random string of ASCII letters and digits.
@@ -36,8 +50,19 @@ def random_alphanum(length):
     :rtype: str
     """
     charset = string.ascii_letters + string.digits
-    n = len(charset)
-    return ''.join(charset[random.randrange(n)] for _ in range(length))
+    return random_string(length, charset)
+
+
+def random_hex(length):
+    """
+    Return a random hex string.
+
+    :param int length: The length of string to return
+    :returns: A random string
+    :rtype: str
+    """
+    charset = ''.join(set(string.hexdigits.lower()))
+    return random_string(length, charset)
 
 
 def snake_to_camel(stringue):

--- a/tests/friend/test_strings.py
+++ b/tests/friend/test_strings.py
@@ -18,17 +18,19 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 import random
+import string
 import unittest
 
 from friend import strings
 
 
 class StringsTests(unittest.TestCase):
-    def test_random_alphanum(self):
+    def test_random_string(self):
+        charset = string.ascii_letters
         for _ in range(100):
             length = random.randint(25, 100)
-            v1 = strings.random_alphanum(length)
-            v2 = strings.random_alphanum(length)
+            v1 = strings.random_string(length, charset)
+            v2 = strings.random_string(length, charset)
             self.assertNotEqual(v1, v2)
             self.assertEqual(len(v1), length)
 


### PR DESCRIPTION
Instead of just `random_alphanum`, the more generic
`random_string` has been added, which is now used to build
`random_alphanum` and `random_hex`.